### PR TITLE
update atob dependency due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "decode-uri-component": "^0.2.0",
     "source-map-url": "^0.4.0",
-    "atob": "^2.0.0",
+    "atob": "^2.1.1",
     "urix": "^0.1.0",
     "resolve-url": "^0.2.1"
   },


### PR DESCRIPTION
please merge this fix to use a newer version of the atob library. The current one (2.0.3 has an memory issue (https://snyk.io/test/npm/atob/2.0.3?severity=high&severity=medium&severity=low)

Afterwards please create an new minor version update too, to let all dependent projects pick up this fix too. 

Thanks,
Stefan